### PR TITLE
fix: SafeInfo guard can be null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -14,7 +14,7 @@ export type SafeInfo = {
   owners: AddressEx[]
   implementation: AddressEx
   modules: AddressEx[]
-  guard: AddressEx
+  guard: AddressEx | null
   fallbackHandler: AddressEx
   version: string
   collectiblesTag: string


### PR DESCRIPTION
## What this PR changes
Changes the SafeInfo's `guard` field to be nullable.

## Why?
This line converts the 0 address which is in the safe-contract to `null`:
https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/converters.rs#L53

Also here is an example Safe response without an transaction guard defined:
```
{
    "address": {
        "value": "0x180E0F9729EB4DD2d740052CB314dC918Ac0570B"
    },
    "chainId": "4",
    "nonce": 5,
    "threshold": 1,
    "owners": [
        {
            "value": "0x3819b800c67Be64029C1393c8b2e0d0d627dADE2"
        }
    ],
    "implementation": {
        "value": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
    },
    "modules": [
        {
            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134"
        },
        {
            "value": "0xaDa0e6Fe72A212240A4b5e7A867c6686e8aF0956"
        },
        {
            "value": "0x4753E44EE22b5a4c9D16877e104D761bB83937A1"
        }
    ],
    "fallbackHandler": {
        "value": "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4"
    },
    "guard": null,
    "version": "1.3.0",
    "implementationVersionState": "UP_TO_DATE",
    "collectiblesTag": "1657556137",
    "txQueuedTag": "1657556137",
    "txHistoryTag": "1657552495"
}
```
