### PR TITLE
Chore: add a script to export OpenAPI types from the CGW Swagger

### DIFF
--- a/scripts/make-cgw-types.sh
+++ b/scripts/make-cgw-types.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p openapi
+curl 'https://safe-client.gnosis.io/openapi.json' > openapi/cgw.json
+npx openapi-typescript openapi/cgw.json --output openapi/cgw.ts


### PR DESCRIPTION
A script that generates TypeScript types from the CGW Swagger.
Unfortunately, CGW only exposes request types, not the responses. Still useful to type the endpoints.