### PR TITLE
Fix: add implementationVersionState to SafeInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ yarn test
 
 N.B.: the e2e tests make actual API calls on staging.
 
-
 ## Gateway API docs
 
 The TypeScript types in this SDK are based on [Rust types](https://safe-global.github.io/safe-client-gateway/docs/routes/index.html) from the Gateway API.

--- a/e2e/safes-read.test.ts
+++ b/e2e/safes-read.test.ts
@@ -6,7 +6,7 @@ describe('getSafeInfo tests', () => {
     setBaseUrl(config.baseUrl)
   })
 
-  it('should get safe info on rinkeby', async () => {
+  it('should get a 1.1.1 Safe on Rinkeby', async () => {
     const address = '0x9B5dc27B104356516B05b02F6166a54F6D74e40B'
     const data = await getSafeInfo('4', address)
 
@@ -22,5 +22,14 @@ describe('getSafeInfo tests', () => {
     ])
     expect(data.threshold).toBe(1)
     expect(data.version).toBe('1.1.1')
+    expect(data.implementationVersionState).toBe('OUTDATED')
+  })
+
+  it('should get a 1.3.0 Safe on Rinkeby', async () => {
+    const address = '0xb3b83bf204C458B461de9B0CD2739DB152b4fa5A'
+    const data = await getSafeInfo('4', address)
+
+    expect(data.version).toBe('1.3.0')
+    expect(data.implementationVersionState).toBe('UP_TO_DATE')
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,15 +7,17 @@ import {
   SafeBalanceResponse,
   SafeCollectibleResponse,
   SafeIncomingTransfersResponse,
-  SafeInfo,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
 } from './types/common'
+import { SafeInfo } from './types/safe-info'
 import { ChainListResponse, ChainInfo } from './types/chains'
 import { SafeAppsResponse } from './types/safe-apps'
 import { MasterCopyReponse } from './types/master-copies'
 import { DecodedDataResponse } from './types/decoded-data'
 import { DEFAULT_BASE_URL } from './config'
+
+export * from './types/safe-info'
 export * from './types/safe-apps'
 export * from './types/transactions'
 export * from './types/chains'

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -6,22 +6,6 @@ export type AddressEx = {
   logoUri?: string
 }
 
-export type SafeInfo = {
-  address: AddressEx
-  chainId: string
-  nonce: number
-  threshold: number
-  owners: AddressEx[]
-  implementation: AddressEx
-  modules: AddressEx[] | null
-  guard: AddressEx | null
-  fallbackHandler: AddressEx
-  version: string
-  collectiblesTag: string
-  txQueuedTag: string
-  txHistoryTag: string
-}
-
 export type FiatCurrencies = string[]
 
 export type OwnedSafes = { safes: string[] }

--- a/src/types/safe-info.ts
+++ b/src/types/safe-info.ts
@@ -1,0 +1,23 @@
+import { AddressEx } from './common'
+
+export enum ImplementationVersionState {
+  UP_TO_DATE = 'UP_TO_DATE',
+  OUTDATED = 'OUTDATED',
+}
+
+export type SafeInfo = {
+  address: AddressEx
+  chainId: string
+  nonce: number
+  threshold: number
+  owners: AddressEx[]
+  implementation: AddressEx
+  implementationVersionState: ImplementationVersionState
+  modules: AddressEx[] | null
+  guard: AddressEx | null
+  fallbackHandler: AddressEx
+  version: string
+  collectiblesTag: string
+  txQueuedTag: string
+  txHistoryTag: string
+}


### PR DESCRIPTION
This is needed to avoid comparing the version of the Safe on the client side.