### PR TITLE
Fix: SafeInfo import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.7.2"
   },
   "scripts": {
-    "lint": "eslint './src/**/*.ts'",
+    "lint": "tsc && eslint './src/**/*.ts'",
     "lint:fix": "yarn lint --fix",
     "types": "yarn tsc",
     "start": "rm -rf dist && webpack --mode production --watch",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,7 +4,6 @@ import {
   SafeBalanceResponse,
   SafeCollectibleResponse,
   SafeIncomingTransfersResponse,
-  SafeInfo,
   SafeModuleTransactionsResponse,
   SafeMultisigTransactionsResponse,
 } from './common'
@@ -15,6 +14,7 @@ import {
   SafeTransactionEstimationRequest,
   TransactionListPage,
 } from './transactions'
+import { SafeInfo } from './safe-info'
 import { ChainListResponse, ChainInfo } from './chains'
 import { SafeAppsResponse } from './safe-apps'
 import { DecodedDataRequest, DecodedDataResponse } from './decoded-data'


### PR DESCRIPTION
Looks like we were lacking type checking in the required checks. I've added tsc to the lint command.