### PR TITLE
Fix: remove deprecated client-side tx statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.2.4",
+  "version": "3.3.4",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -35,8 +35,6 @@ export enum TransactionStatus {
   CANCELLED = 'CANCELLED',
   FAILED = 'FAILED',
   SUCCESS = 'SUCCESS',
-  PENDING = 'PENDING',
-  WILL_BE_REPLACED = 'WILL_BE_REPLACED',
 }
 
 export enum TransferDirection {


### PR DESCRIPTION
These statuses were never returned from the CGW and were client-side only. There's no need for them anymore.