### PR TITLE
Refactor: interface -> type

### DIFF
--- a/src/types/transactions.ts
+++ b/src/types/transactions.ts
@@ -88,7 +88,7 @@ export type NativeCoinTransfer = {
 
 export type TransferInfo = Erc20Transfer | Erc721Transfer | NativeCoinTransfer
 
-export interface Transfer {
+export type Transfer = {
   type: 'Transfer'
   sender: AddressEx
   recipient: AddressEx
@@ -166,7 +166,7 @@ export type SettingsChange = {
   settingsInfo?: SettingsInfo
 }
 
-export interface Custom {
+export type Custom = {
   type: 'Custom'
   to: AddressEx
   dataSize: string


### PR DESCRIPTION
A tiny refactoring: Transfer and Custom were the only two types defined as interfaces accidentally.