### PR TITLE
Add `url` query param to safe-apps endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/safe-react-gateway-sdk",
-  "version": "3.3.5",
+  "version": "3.4.0",
   "main": "dist/index.min.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -505,6 +505,7 @@ export interface operations {
       }
       query?: {
         client_url?: string
+        url?: string
       }
     }
     responses: {


### PR DESCRIPTION
We've added support for the `url` query param to the `safe-apps` endpoint to fetch a single app by URL in https://github.com/safe-global/safe-client-gateway/pull/959, and it's already available on staging https://safe-client.staging.gnosisdev.com/index.html. Production will be released the following Monday.

This PR adds types for the query param.